### PR TITLE
[SHELVED] generator: allow explicit additional permissions

### DIFF
--- a/invenio_records_permissions/policies/base.py
+++ b/invenio_records_permissions/policies/base.py
@@ -104,7 +104,11 @@ class BasePermissionPolicy(Permission):
 
     @property
     def query_filters(self):
-        """List of ElasticSearch query filters."""
+        """List of ElasticSearch query filters.
+
+        These filters consist of additive queries mapping to what the current
+        user should be able to retrieve via search.
+        """
         filters = [
             generator.query_filter(**self.over)
             for generator in self.generators

--- a/invenio_records_permissions/policies/records.py
+++ b/invenio_records_permissions/policies/records.py
@@ -14,7 +14,8 @@ from flask import current_app
 from werkzeug.utils import import_string
 
 from ..errors import UnknownGeneratorError
-from ..generators import Admin, AnyUser, AnyUserIfPublic, Deny, RecordOwners
+from ..generators import Admin, AllowedIdentities, AnyUser, AnyUserIfPublic, \
+    Deny, RecordOwners
 from .base import BasePermissionPolicy
 
 
@@ -52,13 +53,16 @@ class RecordPermissionPolicy(BasePermissionPolicy):
     can_list = [AnyUser()]
     # Create action given to no one. Not even superusers.
     can_create = [Deny()]
-    # Read access given to everyone if public record/files and owners always.
-    can_read = [AnyUserIfPublic(), RecordOwners()]
+    # Read access given according to access rights, owners and any *additional*
+    # explicit read permissions.
+    can_read = [AnyUserIfPublic(), RecordOwners(), AllowedIdentities('read')]
     # can_read_files = [AnyUserIfPublicFiles(), RecordOwners()]
-    # Update access given to record owners.
-    can_update = [RecordOwners()]
-    # Delete access given to admins only.
-    can_delete = [Admin()]
+    # Update access given to record owners and any *additional* explicitly
+    # allowed entities.
+    can_update = [RecordOwners(), AllowedIdentities('update')]
+    # Delete access given to admins and any *additional* explicitly
+    # allowed entities only.
+    can_delete = [Admin(), AllowedIdentities('delete')]
 
 
 def get_record_permission_policy():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,3 +52,37 @@ def create_app(instance_path):
         InvenioSearch(app)
         return app
     return factory
+
+
+@pytest.fixture(scope="session")
+def create_record():
+    """Factory pattern for a loaded Record.
+
+    The returned dict record has the interface of a Record.
+
+    It provides a default value for each required field.
+    """
+    def _create_record(metadata=None):
+        # TODO: Modify according to record schema
+        metadata = metadata or {}
+        record = {
+            "_access": {
+                # TODO: Remove if "access_right" includes it
+                "metadata_restricted": False,
+                "files_restricted": False
+            },
+            "access_right": "open",
+            "title": "This is a record",
+            "description": "This record is a test record",
+            "owners": [1, 2, 3],
+            "deposits": {
+                "owners": [1, 2]
+            },
+            "sys": {
+                "permissions": {},
+            }
+        }
+        record.update(metadata)
+        return record
+
+    return _create_record

--- a/tests/test_permissions_records.py
+++ b/tests/test_permissions_records.py
@@ -7,6 +7,7 @@
 # and/or modify it under the terms of the MIT License; see LICENSE file for
 # more details.
 
+import pytest
 from elasticsearch_dsl import Q
 from flask_principal import ActionNeed, UserNeed
 from invenio_access.permissions import any_user, superuser_access
@@ -18,20 +19,16 @@ from invenio_records_permissions import record_create_permission_factory, \
     record_delete_permission_factory, record_list_permission_factory, \
     record_read_permission_factory, record_update_permission_factory
 
-# TODO: Establish record schema
-record = {
-    "_access": {
-        "metadata_restricted": True,
-        "files_restricted": True
-    },
-    "access_right": "restricted",
-    "title": "This is a record",
-    "description": "This record is a test record",
-    "owners": [1, 2, 3],
-    "deposits": {
-        "owners": [1, 2]
-    }
-}
+
+@pytest.fixture(scope="module")
+def record(create_record):
+    return create_record({
+        "_access": {
+            "metadata_restricted": True,
+            "files_restricted": True
+        },
+        "access_right": "restricted"
+    })
 
 
 def test_record_list_permission_factory(app):
@@ -43,7 +40,7 @@ def test_record_list_permission_factory(app):
     assert list_perm.query_filters == [Q('match_all')]
 
 
-def test_record_create_permission_factory(app):
+def test_record_create_permission_factory(app, record):
     create_perm = record_create_permission_factory(record)
 
     assert create_perm.needs == {superuser_access}
@@ -54,12 +51,11 @@ def test_record_create_permission_factory(app):
     assert create_perm.query_filters == [~Q('match_all')]
 
 
-def test_record_read_permission_factory(app, mocker):
+def test_record_read_permission_factory(app, mocker, record):
     # Assumes identity + provides are well initialized for user
     # TODO: Integration test for g.identity.provides
     patched_g = mocker.patch('invenio_records_permissions.generators.g')
     patched_g.identity.provides = [mocker.Mock(method='id', value=1)]
-
     read_perm = record_read_permission_factory(record)
 
     assert read_perm.needs == {
@@ -70,15 +66,15 @@ def test_record_read_permission_factory(app, mocker):
     }
     assert read_perm.excludes == set()
     assert read_perm.query_filters == [
-        Q('term', **{"_access.metadata_restricted": False}),
-        Q('term', owners=1)
+        Q('term', **{"access_right": "open"}),
+        Q('term', owners=1),
+        Q('term', **{'sys.permissions.can_read': {'type': 'person', 'id': 1}})
     ]
 
 
-def test_update_permission_factory(app, mocker):
+def test_update_permission_factory(app, mocker, record):
     patched_g = mocker.patch('invenio_records_permissions.generators.g')
     patched_g.identity.provides = [mocker.Mock(method='id', value=4)]
-
     permission = record_update_permission_factory(record)
 
     assert permission.needs == {
@@ -89,11 +85,19 @@ def test_update_permission_factory(app, mocker):
     }
     assert permission.excludes == set()
     assert permission.query_filters == [
-        Q('term', owners=4)
+        Q('term', owners=4),
+        Q(
+            'term',
+            **{
+                'sys.permissions.can_update': {'type': 'person', 'id': 4}
+            }
+        )
     ]
 
 
-def test_delete_permission_factory(app):
+def test_delete_permission_factory(app, mocker, record):
+    patched_g = mocker.patch('invenio_records_permissions.generators.g')
+    patched_g.identity.provides = [mocker.Mock(method='id', value=4)]
     permission = record_delete_permission_factory(record)
 
     assert permission.needs == {
@@ -101,4 +105,11 @@ def test_delete_permission_factory(app):
         ActionNeed('admin-access')
     }
     assert permission.excludes == set()
-    assert permission.query_filters == []
+    assert permission.query_filters == [
+        Q(
+            'term',
+            **{
+                'sys.permissions.can_delete': {'type': 'person', 'id': 4}
+            }
+        ),
+    ]


### PR DESCRIPTION
- defines a factory to group record creation together
- Implements https://github.com/inveniosoftware/rfcs/pull/12 -- 
  not taking "access_right" into account in the end since it seemed 
  too purist (but open to adding it back).  
- closes #16 