### PR TITLE
global: change versioning scheme

### DIFF
--- a/invenio_records_permissions/version.py
+++ b/invenio_records_permissions/version.py
@@ -15,4 +15,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0a6'
+__version__ = '0.7.0'


### PR DESCRIPTION
Changes:

* ~~Remove support for Python 2~~  (Done in https://github.com/inveniosoftware/invenio-records-permissions/pull/41)
* ~~Bump Python 3 version~~  (Done in https://github.com/inveniosoftware/invenio-records-permissions/pull/41)
* ~~Bump some dependencies due to Werkzeug imports~~ (Done in https://github.com/inveniosoftware/invenio-records-permissions/pull/41)

* Release with new versioning scheme

Note: This module has not been updated this month and it's the first on the chain for release, so I though we would start already :) 

@lnielsen just wondering if `5 - Production/Stable` is the correct. Anything else below (alpha, beta, dev, rc) will be picked as pre-release AFAIK. No? --> Discussed IRL, keep *alpha* it's just descriptive, not used for any other reason.

Requires: https://github.com/inveniosoftware/invenio-records-permissions/pull/41 and rebase ofc
Closes: https://github.com/inveniosoftware/invenio-records-permissions/issues/38