### PR TITLE
record policy: remove bidict usage and add bucket-read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
     - REQUIREMENTS=devel EXTRAS=all,postgresql,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
 
 python:
-  - "3.5"
+  - "3.6"
 
 before_install:
   - "mkdir /tmp/elasticsearch"
@@ -83,6 +83,6 @@ deploy:
   distributions: "compile_catalog sdist bdist_wheel"
   on:
     tags: true
-    python: "3.5"
+    python: "3.6"
     repo: inveniosoftware/invenio-records-permissions
     condition: $DEPLOY = true

--- a/invenio_records_permissions/policies/records.py
+++ b/invenio_records_permissions/policies/records.py
@@ -10,7 +10,6 @@
 """Access controls for records."""
 
 import six
-from bidict import bidict
 from flask import current_app
 from werkzeug.utils import import_string
 
@@ -45,10 +44,11 @@ def obj_or_import_string(value, default=None):
 class RecordPermissionPolicy(BasePermissionPolicy):
     """Access control configuration for records."""
 
-    NEED_LABEL_TO_ACTION = bidict({
+    NEED_LABEL_TO_ACTION = {
         'bucket-update': 'update_files',
+        'bucket-read': 'read_files',
         'object-read': 'read_files',
-    })
+    }
 
     # Read access given to everyone.
     can_list = [AnyUser()]

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ install_requires = [
     # https://invenio.readthedocs.io/en/latest/releases/maintenance-policy.html
     'invenio-access>=1.3.0,<1.4.0',
     'invenio-records-files>=1.2.0,<1.3.0',
-    'bidict>=0.18.3'
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = [
     'pytest-mock>=1.6.0',
     'pytest-pep8>=1.0.6',
     'pytest-invenio>=1.0.5',
-    'invenio-accounts>=1.1.1,<1.2.0',
+    'invenio-accounts>=1.1.2,<1.2.0',
     'invenio_app>=1.2.3,<1.3.0',
     sphinx_require,
 ]
@@ -72,7 +72,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask-BabelEx>=0.9.3',
+    'Flask-BabelEx>=0.9.4',
     'Flask-Principal>=0.4.0,<0.5.0',
     # Because of versioning policy that may admit minor incompatible (!)
     # backward change we also place an upper limit

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Development Status :: 3 - Alpha',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Changes

* Adds `bucket-read` to the `NEEDS_TO_ACTION` mapping
* Removes usage of `bidict`

Once integrated and released would close https://github.com/inveniosoftware/invenio-app-rdm/issues/54