### PR TITLE
Search filter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.pythonPath": "/home/ppanero/.virtualenvs/invenio-records-permissions/bin/python"
-}

--- a/invenio_records_permissions/api.py
+++ b/invenio_records_permissions/api.py
@@ -12,11 +12,18 @@ from elasticsearch_dsl.query import Q
 from flask import current_app
 from invenio_search.api import DefaultFilter, RecordsSearch
 
+from .factories import record_read_permission_factory
+
 
 def rdm_records_filter():
     """Records filter."""
     # TODO: Implement with new permissions metadata
-    perm_factory = current_app.config['RECORDS_REST_ENDPOINTS']['recid']['read_permission_factory_imp']()  # noqa
+    try:
+        perm_factory = current_app.config["RECORDS_REST_ENDPOINTS"]["recid"][
+            "read_permission_factory_imp"
+        ]()  # noqa
+    except KeyError:
+        perm_factory = record_read_permission_factory
     # FIXME: this might fail if factory returns None, meaning no "query_filter"
     # was implemente in the generators. However, IfPublic should always be
     # there.
@@ -40,6 +47,6 @@ class RecordsSearch(RecordsSearch):
     class Meta:
         """Default index and filter for frontpage search."""
 
-        index = 'records'
+        index = "records"
         doc_types = None
         default_filter = DefaultFilter(rdm_records_filter)

--- a/invenio_records_permissions/api.py
+++ b/invenio_records_permissions/api.py
@@ -8,8 +8,6 @@
 
 """Invenio Records Permissions API."""
 
-from __future__ import absolute_import, print_function
-
 from elasticsearch_dsl.query import Q
 from flask import current_app
 from invenio_search.api import DefaultFilter, RecordsSearch


### PR DESCRIPTION
Two thoughts:

1- I think the `api.py` file in its entirity should be in `rdm-records`. It is a specify filter.
2- That would allow us to fix the awful dependency on getting the read perm factory...

Lastly, this removes the `.vscode` folder that was commited initially. My bad.

Note: It is not my intention to merge this PR, is just for "showing" the issue purposes. We should move it to RDM-Rercords. Nonetheless, is blocking for the work on invenio-resources.