### PR TITLE
generators: add SystemProcess generator

### DIFF
--- a/invenio_records_permissions/generators.py
+++ b/invenio_records_permissions/generators.py
@@ -17,7 +17,7 @@ from itertools import chain
 from elasticsearch_dsl.query import Q
 from flask_principal import ActionNeed, UserNeed
 from invenio_access.permissions import any_user, authenticated_user, \
-    superuser_access
+    superuser_access, system_process
 from invenio_records.api import Record
 
 
@@ -73,6 +73,23 @@ class SuperUser(Generator):
 
     def query_filter(self, **kwargs):
         """Filters for current identity as super user."""
+        # TODO: Implement with new permissions metadata
+        return []
+
+
+class SystemProcess(Generator):
+    """Allows system processes."""
+
+    def __init__(self):
+        """Constructor."""
+        super(SystemProcess, self).__init__()
+
+    def needs(self, **kwargs):
+        """Enabling Needs."""
+        return [system_process]
+
+    def query_filter(self, **kwargs):
+        """Filters for current identity as system process."""
         # TODO: Implement with new permissions metadata
         return []
 

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,9 @@ setup_requires = [
 ]
 
 install_requires = [
-    'invenio-access>=1.4.1,<2.0.0',
+    'invenio-access>=1.4.2,<2.0.0',
     'invenio-i18n>=1.2.0',
-    'invenio-records>=1.3.2'
+    'invenio-records>=1.4.0'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
closes inveniosoftware/invenio-vocabularies#22

requires the `system_process` role added to `invenio-access` in https://github.com/inveniosoftware/invenio-access/pull/184
provides a generator for it