### PR TITLE
bugfix: add invenio_config to testpaths in tool:pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,5 +89,5 @@ ignore =
 
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_records_permissions --cov-report=term-missing
-testpaths = tests
+testpaths = tests invenio_records_permissions
 live_server_scope = module


### PR DESCRIPTION
otherwise e.g. black is not tested in this directory
