### PR TITLE
1792 superuser can search all

### DIFF
--- a/invenio_records_permissions/api.py
+++ b/invenio_records_permissions/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019-2020 CERN.
-# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2019-2022 Northwestern University.
 #
 # Invenio-Records-Permissions is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
@@ -9,16 +9,16 @@
 
 """Invenio Records Permissions API."""
 
+from functools import reduce
+
 from invenio_search.engine import dsl
 
 
 def permission_filter(permission):
-    """Permission filter."""
-    # NOTE: flask-principal overwrites __bool() and access g
-    if permission is not None:
-        qf = None
-        for f in permission.query_filters:
-            qf = qf | f if qf else f
-        return qf
-    else:
-        return dsl.Q()
+    """Generates the Query that returns visible records from a search.
+
+    Q() is the "match all" Query.
+    """
+    query_filters = permission.query_filters if permission is not None else []
+    query_filters = query_filters or [dsl.Q()]
+    return reduce(lambda f1, f2: f1 | f2, query_filters)

--- a/invenio_records_permissions/generators.py
+++ b/invenio_records_permissions/generators.py
@@ -9,7 +9,6 @@
 
 """Invenio Records Permissions Generators."""
 
-import json
 import operator
 from functools import reduce
 from itertools import chain
@@ -22,7 +21,6 @@ from invenio_access.permissions import (
     superuser_access,
     system_process,
 )
-from invenio_records.api import Record
 from invenio_search.engine import dsl
 
 
@@ -63,25 +61,6 @@ class AnyUser(Generator):
         """Match all in search."""
         # TODO: Implement with new permissions metadata
         return dsl.Q("match_all")
-
-
-class SuperUser(Generator):
-    """Allows super users."""
-
-    def __init__(self):
-        """Constructor."""
-        super(SuperUser, self).__init__()
-
-    def needs(self, **kwargs):
-        """Enabling Needs."""
-        return [superuser_access]
-
-    def query_filter(self, identity=None, **kwargs):
-        """Filters for current identity as super user."""
-        if superuser_access in identity.provides:
-            return dsl.Q("match_all")
-        else:
-            return []
 
 
 class SystemProcess(Generator):

--- a/invenio_records_permissions/policies/base.py
+++ b/invenio_records_permissions/policies/base.py
@@ -11,9 +11,9 @@
 
 from itertools import chain
 
-from elasticsearch_dsl.query import Q
 from invenio_access import Permission
 from invenio_access.permissions import superuser_access
+from invenio_search.engine import dsl
 
 from ..generators import Disable
 
@@ -126,6 +126,6 @@ class BasePermissionPolicy(Permission):
         identity = self.over.get("identity")
         identity_provides = identity.provides if identity else set()
         if superuser_needs & identity_provides:
-            filters.append(Q("match_all"))
+            filters.append(dsl.Q("match_all"))
 
         return [f for f in filters if f]

--- a/invenio_records_permissions/translations/messages.pot
+++ b/invenio_records_permissions/translations/messages.pot
@@ -7,14 +7,14 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-records-permissions 0.13.0\n"
+"Project-Id-Version: invenio-records-permissions 0.15.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2022-05-27 09:18+0200\n"
+"POT-Creation-Date: 2022-10-03 13:33-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.1\n"
+"Generated-By: Babel 2.10.3\n"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tests =
     pytest-black>=0.3.0
     pytest-mock>=1.6.0
     pytest-invenio>=2.1.0,<3.0.0
-    invenio-accounts>=1.4.3,<2.0.0
+    invenio-accounts>=2.0.0,<3.0.0
     invenio-app>=1.3.0,<2.0.0
     Sphinx==4.2.0
     invenio-db[mysql,postgresql,versioning]>=1.0.9,<2.0.0

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -11,7 +11,7 @@ import copy
 
 import pytest
 from flask_principal import ActionNeed, UserNeed
-from invenio_access.permissions import any_user, authenticated_user, superuser_access
+from invenio_access.permissions import any_user, authenticated_user
 
 from invenio_records_permissions.generators import (
     Admin,
@@ -22,7 +22,6 @@ from invenio_records_permissions.generators import (
     Disable,
     Generator,
     RecordOwners,
-    SuperUser,
 )
 
 
@@ -40,14 +39,6 @@ def test_any_user():
     assert generator.needs() == [any_user]
     assert generator.excludes() == []
     assert generator.query_filter().to_dict() == {"match_all": {}}
-
-
-def test_superuser():
-    generator = SuperUser()
-
-    assert generator.needs() == [superuser_access]
-    assert generator.excludes() == []
-    # TODO: Test query_filter when new permissions metadata implemented
 
 
 def test_disable():

--- a/tests/test_permissions_base.py
+++ b/tests/test_permissions_base.py
@@ -6,6 +6,7 @@
 # Invenio-Records-Permissions is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
 # more details.
+
 from flask_principal import Identity
 from invenio_access.permissions import any_user
 from invenio_search.engine import dsl
@@ -45,7 +46,7 @@ def test_permission_policy_generators(app):
     assert isinstance(policy(action="random").generators[0], Disable)
 
 
-def test_permission_policy_needs_excludes(superuser_role_need):
+def test_permission_policy_needs_excludes(superusers_role_need):
     create_perm = TestPermissionPolicy(action="create")
     list_perm = TestPermissionPolicy(action="search")
     read_perm = TestPermissionPolicy(action="read")
@@ -53,22 +54,22 @@ def test_permission_policy_needs_excludes(superuser_role_need):
     delete_perm = TestPermissionPolicy(action="delete")
     foo_bar_perm = TestPermissionPolicy(action="foo_bar")
 
-    assert create_perm.needs == {superuser_role_need, any_user}
+    assert create_perm.needs == {superusers_role_need, any_user}
     assert create_perm.excludes == set()
 
-    assert list_perm.needs == {superuser_role_need, any_user}
+    assert list_perm.needs == {superusers_role_need, any_user}
     assert list_perm.excludes == set()
 
-    assert read_perm.needs == {superuser_role_need, any_user}
+    assert read_perm.needs == {superusers_role_need, any_user}
     assert read_perm.excludes == set()
 
-    assert update_perm.needs == {superuser_role_need}
+    assert update_perm.needs == {superusers_role_need}
     assert update_perm.excludes == set()
 
-    assert delete_perm.needs == {superuser_role_need}
+    assert delete_perm.needs == {superusers_role_need}
     assert delete_perm.excludes == set()
 
-    assert foo_bar_perm.needs == {superuser_role_need, any_user}
+    assert foo_bar_perm.needs == {superusers_role_need, any_user}
     assert foo_bar_perm.excludes == set()
 
 

--- a/tests/test_permissions_base.py
+++ b/tests/test_permissions_base.py
@@ -6,9 +6,9 @@
 # Invenio-Records-Permissions is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
 # more details.
-from elasticsearch_dsl import Q
 from flask_principal import Identity
 from invenio_access.permissions import any_user
+from invenio_search.engine import dsl
 
 from invenio_records_permissions.api import permission_filter
 from invenio_records_permissions.generators import AnyUser, Disable
@@ -83,7 +83,7 @@ def test_permission_policy_query_filters(superuser_identity):
     # Superuser
     permission = TestPermissionPolicy(action="baz", identity=superuser_identity)
 
-    assert [Q()] == permission.query_filters
+    assert [dsl.Q()] == permission.query_filters
 
 
 def test_permission_filter(mocker):
@@ -92,19 +92,19 @@ def test_permission_filter(mocker):
     # permission is None
     permission = None
     filter_ = permission_filter(permission)
-    assert Q() == filter_
+    assert dsl.Q() == filter_
 
     # permission.query_filters returns []
     permission = mocker.Mock(query_filters=[])
     filter_ = permission_filter(permission)
-    assert Q() == filter_
+    assert dsl.Q() == filter_
 
     # permission.query_filters returns [Q]
-    permission = mocker.Mock(query_filters=[Q("term", fieldA="valueA")])
+    permission = mocker.Mock(query_filters=[dsl.Q("term", fieldA="valueA")])
     filter_ = permission_filter(permission)
-    assert Q("term", fieldA="valueA") == filter_
+    assert dsl.Q("term", fieldA="valueA") == filter_
 
     # permission.query_filters returns [Q1, Q2]
-    permission = mocker.Mock(query_filters=[Q(), Q("term", fieldA="valueA")])
+    permission = mocker.Mock(query_filters=[dsl.Q(), dsl.Q("term", fieldA="valueA")])
     filter_ = permission_filter(permission)
-    assert Q() == filter_
+    assert dsl.Q() == filter_

--- a/tests/test_permissions_base.py
+++ b/tests/test_permissions_base.py
@@ -6,6 +6,7 @@
 # Invenio-Records-Permissions is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
 # more details.
+from collections import namedtuple
 
 from invenio_access.permissions import any_user
 
@@ -67,3 +68,20 @@ def test_permission_policy_needs_excludes(superuser_role_need):
 
     assert foo_bar_perm.needs == {superuser_role_need, any_user}
     assert foo_bar_perm.excludes == set()
+
+
+def test_permission_policy_query_filters(superuser_identity):
+    class PermissionPolicy(BasePermissionPolicy):
+        can_read = []
+
+    # Any user
+    Identity = namedtuple("Identity", ["provides"])
+    any_user_identity = Identity(provides={any_user})
+    permission = PermissionPolicy(action="read", identity=any_user_identity)
+
+    assert [] == permission.query_filters
+
+    # Superuser
+    permission = PermissionPolicy(action="read", identity=superuser_identity)
+
+    assert [Q("match_all")] == permission.query_filters


### PR DESCRIPTION
- permission: inject superuser-access logic in query_filter [+]
  superuser-access logic was already injected in Permission.needs/excludes, but
  was missing from query_filters. This caused searches by superusers to not
  return all records, even though all records can be seen by superusers.
  closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1792

- permission_filter: fix empty query_filters bug, test and refactor
  There was a problem (a form of Liskov violation) with permission_filter where
  `None` would be returned if query_filters returned []. This would break the search.
  Now, that issue is solved, permission_filter is tested, and refactored a little.

  A better refactoring IMO would place the permission_filter code in Permission.query_filters
  directly and remove the need for search to call this dangling function. If you agree I can create a ticket for this.
