### PR TITLE
tests: implement superuser query_filter test

### DIFF
--- a/invenio_records_permissions/translations/messages.pot
+++ b/invenio_records_permissions/translations/messages.pot
@@ -7,14 +7,14 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-records-permissions 0.13.0\n"
+"Project-Id-Version: invenio-records-permissions 0.15.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2022-05-27 09:18+0200\n"
+"POT-Creation-Date: 2022-10-04 10:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.1\n"
+"Generated-By: Babel 2.10.3\n"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tests =
     pytest-black>=0.3.0
     pytest-mock>=1.6.0
     pytest-invenio>=2.1.0,<3.0.0
-    invenio-accounts>=1.4.3,<2.0.0
+    invenio-accounts>=2.0.0,<3.0.0
     invenio-app>=1.3.0,<2.0.0
     Sphinx==4.2.0
     invenio-db[mysql,postgresql,versioning]>=1.0.9,<2.0.0

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -42,12 +42,16 @@ def test_any_user():
     assert generator.query_filter().to_dict() == {"match_all": {}}
 
 
-def test_superuser():
+def test_superuser(superuser_identity):
     generator = SuperUser()
 
     assert generator.needs() == [superuser_access]
     assert generator.excludes() == []
-    # TODO: Test query_filter when new permissions metadata implemented
+    breakpoint()
+    assert generator.query_filter(identity=superuser_identity).to_dict() == {
+        "match_all": {}
+    }
+    assert generator.query_filter() == []
 
 
 def test_disable():


### PR DESCRIPTION
This PR is merely to showcase the fact that the generator is wrong. It is checking for an _action_ need in a list of _role_ needs. This will result in an error in the tests as follows, since it will return `[]` no a `Q(...)` object.

```
FAILED tests/test_generators.py::test_superuser - AttributeError: 'list' object has no attribute 'to_dict'
```

<img width="1792" alt="Screenshot 2022-10-04 at 10 56 25" src="https://user-images.githubusercontent.com/6756943/193778690-c85cd8e8-9ced-4c17-ac90-83bf5a42a5d9.png">

kudos to @ntarocco for finding out!

Extra question, why do we return `[]`, I guess because there is a noop in the DSL and `None` would mean extra checks in the policy.

----- More -----

`self._load_permissions()` is not called anywhere in the [`query_filters` generation](https://github.com/inveniosoftware/invenio-records-permissions/blob/master/invenio_records_permissions/policies/base.py#L114). On the other hand, it is used for `needs` and `excludes` and that's why it works for permissions (but not for search).