### PR TITLE
generators: fix AdmiAction permission check

### DIFF
--- a/invenio_records_permissions/generators.py
+++ b/invenio_records_permissions/generators.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2019-2023 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2024 Ubiquity Press.
 #
 # Invenio-Records-Permissions is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
@@ -16,7 +17,7 @@ from itertools import chain
 
 from flask import current_app
 from flask_principal import ActionNeed, UserNeed
-from invenio_access import ActionRoles, ActionUsers
+from invenio_access import ActionRoles, ActionUsers, Permission
 from invenio_access.permissions import (
     any_user,
     authenticated_user,
@@ -248,11 +249,11 @@ class AdminAction(Generator):
         """Enabling Needs."""
         return [self.action]
 
-    def query_filter(self, identity, **kwargs):
+    def query_filter(self, identity=None, **kwargs):
         """Not implemented at this level."""
-        for need in identity.provides:
-            if need.value == self.action.value:
-                return dsl.Q("match_all")
+        permission = Permission(self.action)
+        if identity and permission.allows(identity):
+            return dsl.Q("match_all")
         return []
 
 


### PR DESCRIPTION
* Checking permissions using `action.value` can lead to undesired situations, changing to use `Permission.allow` instead.


## Example

```python
from invenio_access.permissions import Permission
from invenio_access.utils import get_identity
from invenio_accounts.proxies import current_datastore
from invenio_users_resources.permissions import user_management_action
from invenio_records_permissions.generators import AdminAction

user = current_datastore.get_user_by_id(4)
identity = get_identity(user)
identity.provides
# {Need(method='id', value=4), Need(method='role', value='administration')}

admin_user = AdminAction(user_management_action)
admin_user.needs()
# [Need(method='action', value='administration-moderation')]

for need in identity.provides:
    if need.value == admin_user.action.value:
        print("Match!")
# Doesn't match

Permission(admin_user.action)
# <Permission needs={Need(method='role', value='administration'), Need(method='id', value=1), Need(method='role', value='admin')} excludes=set()>
Permission(admin_user.action).allows(identity)
# True

# Differnt user
user = current_datastore.get_user_by_id(2)
identity = get_identity(user)
identity.provides
# {Need(method='id', value=2)}

Permission(admin_user.action).allows(identity)
# False
```

### Permission issue

If there is a group/role named as the action, administration-moderation, with no permissions associated with it. It will grant access.

```python
user = current_datastore.get_user_by_id(2)
identity = get_identity(user)
identity.provides
#{Need(method='id', value=2), Need(method='role', value='administration-moderation')}

for need in identity.provides:
    if need.value == admin_user.action.value:
        print("Match!")
# Match!
```
