### PR TITLE
feat(typing): Returning `None` instead of `[]` in Generator

### DIFF
--- a/invenio_records_permissions/generators.py
+++ b/invenio_records_permissions/generators.py
@@ -16,7 +16,7 @@ from functools import reduce
 from itertools import chain
 
 from flask import current_app
-from flask_principal import ActionNeed, UserNeed
+from flask_principal import UserNeed
 from invenio_access import ActionRoles, ActionUsers, Permission
 from invenio_access.permissions import (
     any_user,
@@ -46,7 +46,7 @@ class Generator(object):
 
     def query_filter(self, **kwargs):
         """Search filters."""
-        return []
+        return None
 
 
 class AnyUser(Generator):
@@ -74,7 +74,7 @@ class SystemProcess(Generator):
         if system_process in identity.provides:
             return dsl.Q("match_all")
         else:
-            return []
+            return None
 
 
 class SystemProcessWithoutSuperUser(SystemProcess):
@@ -118,7 +118,7 @@ class RecordOwners(Generator):
         for need in identity.provides:
             if need.method == "id":
                 return dsl.Q("term", owners=need.value)
-        return []
+        return None
 
 
 class AnyUserIfPublic(Generator):
@@ -210,7 +210,7 @@ class AllowedByAccessLevel(Generator):
         )
 
         if not id_need:
-            return []
+            return None
 
         # To get the record in the search results, the access level must
         # have been put in the 'read' array
@@ -254,7 +254,7 @@ class AdminAction(Generator):
         permission = Permission(self.action)
         if identity and permission.allows(identity):
             return dsl.Q("match_all")
-        return []
+        return None
 
 
 class ConditionalGenerator(Generator):

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -37,7 +37,7 @@ def test_generator():
 
     assert generator.needs() == []
     assert generator.excludes() == []
-    assert generator.query_filter() == []
+    assert generator.query_filter() is None
 
 
 def test_any_user():
@@ -181,7 +181,7 @@ def test_allowedbyaccesslevels_query_filter(mocker):
         identity=mocker.Mock(provides=[mocker.Mock(method="foo", value=1)])
     )
 
-    assert query_filter == []
+    assert query_filter is None
 
 
 def test_conditional(create_record, mocker):


### PR DESCRIPTION
### Description

The permission generator exposes a `query_filter` method that returns either an instance of `Query` (for example, in opensearch implementation it is `opensearch_dsl.query.Query`) or a falsy value. This is evaluated, for example, in BasePermissionPolicy: https://github.com/inveniosoftware/invenio-records-permissions/blob/master/invenio_records_permissions/policies/base.py#L136

```python
    filters = [generator.query_filter(**self.over) for generator in self.generators]
    return [f for f in filters if f]
```        

The falsy value used was `[]`, probably to be consistent with `needs` and `excludes` methods on the same class which return empty list.

However, allowing `query_filter` to return either `Query` or `[]` makes it impossible to define a clean and accurate return type in typing stubs. A type such as `Query | list` would be misleading, as it implies that a generator may return a list of `Query` objects, which is not valid and would result in a runtime error.

This PR proposes returning `None` instead of `[]`. The behavior remains functionally equivalent, but the return type can now be expressed precisely as `Query | None`.

Although this change is backward-incompatible, a major version bump will already be required for https://github.com/inveniosoftware/invenio-records-permissions/pull/119, so this adjustment could be included as part of that release.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
